### PR TITLE
iptables-related changes

### DIFF
--- a/torjail
+++ b/torjail
@@ -107,7 +107,7 @@ cleanup() {
     fi
     iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
     iptables -D INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-    iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
+#   iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
 
   fi
 
@@ -375,12 +375,13 @@ if [ $? -ne 0 ]; then
   # this is needed to avoid reaching other interfaces
   iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
   iptables -I INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-  iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
+#  iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
   if [[ $HIDDENSERVICE = y ]]; then
     iptables -I INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT
     iptables -I INPUT -i in-$NAME -p tcp --destination $IPNETNS --dport $HSERVICEPORT -j ACCEPT
   fi
   # while we inserted the rules above, the DROP rule must be appended instead
+  iptables -A INPUT -i in-$NAME -j DROP
   iptables -A INPUT -i in-$NAME -j DROP
 
   # executing tor

--- a/torjail
+++ b/torjail
@@ -380,7 +380,8 @@ if [ $? -ne 0 ]; then
     iptables -I INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT
     iptables -I INPUT -i in-$NAME -p tcp --destination $IPNETNS --dport $HSERVICEPORT -j ACCEPT
   fi
-  iptables -I INPUT -i in-$NAME -j DROP
+  # while we inserted the rules above, the DROP rule must be appended instead
+  iptables -A INPUT -i in-$NAME -j DROP
 
   # executing tor
   print G " * Creating the TOR configuration file..."

--- a/torjail
+++ b/torjail
@@ -107,8 +107,6 @@ cleanup() {
     fi
     iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
     iptables -D INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-  # iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
-
   fi
 
   print G " * Removing the temporary resolve file $RESOLVEFILE..."
@@ -374,7 +372,6 @@ if [ $? -ne 0 ]; then
   # REJECT all traffic coming from torjail
   # this is needed to avoid reaching other interfaces
   iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
-# iptables -I INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
   iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
   if [[ $HIDDENSERVICE = y ]]; then
     iptables -I INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT

--- a/torjail
+++ b/torjail
@@ -107,7 +107,7 @@ cleanup() {
     fi
     iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
     iptables -D INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-    iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
+  # iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
 
   fi
 
@@ -374,7 +374,7 @@ if [ $? -ne 0 ]; then
   # REJECT all traffic coming from torjail
   # this is needed to avoid reaching other interfaces
   iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
-  iptables -I INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
+# iptables -I INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
   iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
   if [[ $HIDDENSERVICE = y ]]; then
     iptables -I INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT

--- a/torjail
+++ b/torjail
@@ -373,14 +373,14 @@ if [ $? -ne 0 ]; then
 
   # REJECT all traffic coming from torjail
   # this is needed to avoid reaching other interfaces
-  iptables -A INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
-  iptables -A INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-  iptables -A INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
+  iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
+  iptables -I INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
+  iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
   if [[ $HIDDENSERVICE = y ]]; then
-    iptables -A INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT
-    iptables -A INPUT -i in-$NAME -p tcp --destination $IPNETNS --dport $HSERVICEPORT -j ACCEPT
+    iptables -I INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT
+    iptables -I INPUT -i in-$NAME -p tcp --destination $IPNETNS --dport $HSERVICEPORT -j ACCEPT
   fi
-  iptables -A INPUT -i in-$NAME -j DROP
+  iptables -I INPUT -i in-$NAME -j DROP
 
   # executing tor
   print G " * Creating the TOR configuration file..."

--- a/torjail
+++ b/torjail
@@ -107,7 +107,7 @@ cleanup() {
     fi
     iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
     iptables -D INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-#   iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
+    iptables -D INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
 
   fi
 
@@ -375,13 +375,12 @@ if [ $? -ne 0 ]; then
   # this is needed to avoid reaching other interfaces
   iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 5354 -j ACCEPT
   iptables -I INPUT -i in-$NAME -p tcp --destination $IPHOST --dport 9040 -j ACCEPT
-#  iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
+  iptables -I INPUT -i in-$NAME -p udp --destination $IPHOST --dport 9040 -j ACCEPT
   if [[ $HIDDENSERVICE = y ]]; then
     iptables -I INPUT -i in-$NAME -p tcp --source $IPNETNS --sport $HSERVICEPORT -j ACCEPT
     iptables -I INPUT -i in-$NAME -p tcp --destination $IPNETNS --dport $HSERVICEPORT -j ACCEPT
   fi
   # while we inserted the rules above, the DROP rule must be appended instead
-  iptables -A INPUT -i in-$NAME -j DROP
   iptables -A INPUT -i in-$NAME -j DROP
 
   # executing tor


### PR DESCRIPTION
The reasoning is simple: If there are already existing globally blocking rules in the chains then torjail's rules wouldn't work. On my first run with torjail I was pulling my hair, trying to get it to work, until I figured out that packets don't even reach these rules in my chains...